### PR TITLE
clarify the limit of compute cluster name

### DIFF
--- a/04-Working_with_Compute.ipynb
+++ b/04-Working_with_Compute.ipynb
@@ -277,7 +277,7 @@
     "\n",
     "Azure ML supports a range of compute targets, which you can define in your workpace and use to run experiments; paying for the resources only when using them. In this case, we'll run the diabetes training experiment on a compute cluster with a unique name of your choosing, so let's verify that exists (and if not, create it) so we can use it to run training experiments.\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to a unique name for your compute cluster in the code below before running it!"
+    "> **Important**: Change *your-compute-cluster* to a unique name with the length of 2 to 16 characters for your compute cluster in the code below before running it!"
    ]
   },
   {


### PR DESCRIPTION
the limit currently set by Azure ML is 2 to 16 characters. Giving a longer name will throw error.